### PR TITLE
Include names and sources even when empty

### DIFF
--- a/sourcemap.go
+++ b/sourcemap.go
@@ -12,8 +12,8 @@ type Map struct {
 	Version         int      `json:"version"`
 	File            string   `json:"file,omitempty"`
 	SourceRoot      string   `json:"sourceRoot,omitempty"`
-	Sources         []string `json:"sources,omitempty"`
-	Names           []string `json:"names,omitempty"`
+	Sources         []string `json:"sources"`
+	Names           []string `json:"names"`
 	Mappings        string   `json:"mappings"`
 	decodedMappings []*Mapping
 }


### PR DESCRIPTION
### Problem

The `names` and `sources` fields are not optional according to the [source maps spec](https://sourcemaps.info/spec.html). Omitting them when they are empty causes source map parsers that expect them to always be present to crash. We are using the Dart [source_maps package](https://pub.dev/packages/source_maps) to parse stack traces that include frames originating in both Dart and Go code (the Go code is compiled to Js using gopherjs). We've run into exceptions parsing these types of stack traces due to the absence of the `names` field in the Go source maps.

### Solution
This changes the json encoding of those fields so they are no longer omitted when empty.