### PR TITLE
Include empty lists rather than "null" for Names and Sources

### DIFF
--- a/sourcemap.go
+++ b/sourcemap.go
@@ -223,6 +223,12 @@ func (m *Map) WriteTo(w io.Writer) error {
 	if m.decodedMappings != nil {
 		m.EncodeMappings()
 	}
+	if m.Names == nil {
+		m.Names = make([]string, 0)
+	}
+	if m.Sources == nil {
+		m.Sources = make([]string, 0)
+	}
 	enc := json.NewEncoder(w)
 	return enc.Encode(m)
 }

--- a/sourcemap_test.go
+++ b/sourcemap_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 const testFile = `{"version":3,"file":"min.js","sourceRoot":"/the/root","sources":["one.js","two.js"],"names":["bar","baz","n"],"mappings":"CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID;CCDb,IAAI,IAAM,SAAUE,GAClB,OAAOA"}` + "\n"
+const testFileWithoutNames = `{"version":3,"file":"min.js","sourceRoot":"/the/root","sources":["one.js","two.js"],"mappings":"CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID;CCDb,IAAI,IAAM,SAAUE,GAClB,OAAOA"}` + "\n"
+const testFileWithoutSources = `{"version":3,"file":"min.js","sourceRoot":"/the/root","names":["bar","baz","n"],"mappings":"CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID;CCDb,IAAI,IAAM,SAAUE,GAClB,OAAOA"}`
 
 func TestReadFrom(t *testing.T) {
 	m, err := ReadFrom(strings.NewReader(testFile))
@@ -55,6 +57,41 @@ func TestWriteTo(t *testing.T) {
 		t.Fatal(err)
 	}
 	if b.String() != testFile {
+		t.Error(b.String())
+	}
+}
+
+func TestWriteToShouldIncludeEmptyNames(t *testing.T) {
+	m, err := ReadFrom(strings.NewReader(testFileWithoutNames))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.Names != nil {
+		t.Error("Names expected to be nil")
+	}
+	b := bytes.NewBuffer(nil)
+	if err := m.WriteTo(b); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(b.String(), `"names":[]`) {
+		t.Error(b.String())
+	}
+}
+
+func TestWriteToShouldIncludeEmptySources(t *testing.T) {
+
+	m, err := ReadFrom(strings.NewReader(testFileWithoutSources))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.Sources != nil {
+		t.Error("Sources expected to be nil")
+	}
+	b := bytes.NewBuffer(nil)
+	if err := m.WriteTo(b); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(b.String(), `"sources":[]`) {
 		t.Error(b.String())
 	}
 }

--- a/sourcemap_test.go
+++ b/sourcemap_test.go
@@ -74,7 +74,7 @@ func TestWriteToShouldIncludeEmptyNames(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !strings.Contains(b.String(), `"names":[]`) {
-		t.Error(b.String())
+		t.Error(`Source map expected to include '"names":[]'`, "\n", b.String())
 	}
 }
 
@@ -92,6 +92,6 @@ func TestWriteToShouldIncludeEmptySources(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !strings.Contains(b.String(), `"sources":[]`) {
-		t.Error(b.String())
+		t.Error(`Source map expected to include '"sources":[]'`, "\n", b.String())
 	}
 }


### PR DESCRIPTION
### Problem:
I submitted [a PR recently](https://github.com/neelance/sourcemap/pull/2) to ensure the `names` and `sources` keys are included in source maps even when they are empty. I failed to fully test it and didn't notice that if they are `null` they will be written out to the source map as `"names":null` rather than `"names":[]`. 🤕 The latter is the behavior that should be expected.

### Solution:
I updated the `WriteTo` method to check if either of those fields is `nil` and set it to an empty `[]string` before json encoding the map. This ensures we will always see an empty list in the map rather than `null`. I added a couple unit tests to cover this behavior.

FYI: @neelance 